### PR TITLE
Fixes for QuickAssist (QAT) multithreading

### DIFF
--- a/wolfcrypt/src/async.c
+++ b/wolfcrypt/src/async.c
@@ -416,6 +416,7 @@ int wolfAsync_DevCopy(WC_ASYNC_DEV* src, WC_ASYNC_DEV* dst)
     return ret;
 }
 
+/* called from `wolfSSL_AsyncPop` to check if event is done and deliver async return code */
 int wolfAsync_EventPop(WOLF_EVENT* event, enum WOLF_EVENT_TYPE event_type)
 {
     int ret;
@@ -802,13 +803,6 @@ int wc_AsyncGetNumberOfCpus(void)
 
     numCpus = (int)sysconf(_SC_NPROCESSORS_ONLN);
 
-#ifdef HAVE_INTEL_QA
-    /* for QuickAssist make sure and only use one thread->CPU per crypto instance */
-    if (numCpus > IntelQaNumInstances()) {
-        numCpus = IntelQaNumInstances();
-    }
-#endif
-
     return numCpus;
 }
 
@@ -934,7 +928,6 @@ int wc_AsyncThreadCreate(pthread_t *thread,
         return 0;
     }
 #endif /* __MACH__ */
-
 
 int wc_AsyncThreadBind(pthread_t *thread, word32 logicalCore)
 {

--- a/wolfssl/wolfcrypt/port/intel/quickassist.h
+++ b/wolfssl/wolfcrypt/port/intel/quickassist.h
@@ -60,7 +60,7 @@
     #define QAT_MAX_DEVICES  (1)  /* maximum number of QAT cards */
 #endif
 #ifndef QAT_MAX_PENDING
-    #define QAT_MAX_PENDING  (20) /* maximum number of concurent operations */
+    #define QAT_MAX_PENDING  (15) /* 120/num_threads = max num of concurent ops */
 #endif
 #ifndef QAT_RETRY_LIMIT
     #define QAT_RETRY_LIMIT  (100)
@@ -195,7 +195,6 @@ typedef struct IntelQaDev {
             CpaCyDrbgGenOpData opData;
             CpaCyDrbgSessionHandle handle;
             CpaFlatBuffer pOut;
-            Cpa32U handleSize;
         } drbg;
     } op;
 


### PR DESCRIPTION
Fix to not set return code until after callback cleanup. Disable thread binding to specific CPU by default (enabled now with `WC_ASYNC_THREAD_BIND`). Added optional define `QAT_USE_POLLING_CHECK ` to have only one thread polling at a time (not required and doesn't improve performance). Reduced default QAT_MAX_PENDING for benchmark to 15 (120/num_threads).