### PR TITLE
Fix for HMAC QAT when block size aligned

### DIFF
--- a/wolfssl/wolfcrypt/port/intel/quickassist.h
+++ b/wolfssl/wolfcrypt/port/intel/quickassist.h
@@ -114,6 +114,8 @@ typedef struct IntelQaSymCtx {
 
 typedef void (*IntelQaFreeFunc)(struct WC_ASYNC_DEV*);
 
+#define MAX_QAT_HASH_BUFFERS 2
+
 /* QuickAssist device */
 typedef struct IntelQaDev {
 	CpaInstanceHandle handle;
@@ -187,6 +189,10 @@ typedef struct IntelQaDev {
             byte* tmpIn; /* tmp buffer to hold anything pending less than block size */
             word32 tmpInSz;
             word32 blockSize;
+
+            int bufferCount;
+            byte* buffers[MAX_QAT_HASH_BUFFERS];
+            word32 buffersSz[MAX_QAT_HASH_BUFFERS];
         } hash;
     #endif
     #ifndef NO_DH


### PR DESCRIPTION
 The last update is cached until final. The QAT HMAC final without any buffers will fail incorrectly (bug in QAT 1.6). Noticed with new HMAC benchmark which uses block sized multiple for updates, which leaves 0 buffers for final operation. Fix was to leave at least on cache entry.