### PR TITLE
Fixes for memory stability on QuickAssist

### DIFF
--- a/wolfcrypt/src/port/intel/README.md
+++ b/wolfcrypt/src/port/intel/README.md
@@ -29,11 +29,11 @@ Note: If you have the older driver installed you may need to remove it or unload
 	
 	
 	```
-	wget https://01.org/sites/default/files/downloads/qat1.7.l.4.4.0-00023.tar.gz
+	curl -o qat1.7.l.4.5.0-00034.tar.gz https://01.org/sites/default/files/downloads/qat1.7.l.4.5.0-00034.tar.gz
 	mkdir QAT1.7
-	mv qat1.7.l.4.4.0-00023.tar.gz QAT1.7
+	mv qat1.7.l.4.5.0-00034.tar.gz QAT1.7
 	cd QAT1.7
-	tar -xvzf qat1.7.l.4.4.0-00023.tar.gz
+	tar -xvzf qat1.7.l.4.5.0-00034.tar.gz
 
 	./configure
 	make

--- a/wolfcrypt/src/port/intel/quickassist.c
+++ b/wolfcrypt/src/port/intel/quickassist.c
@@ -505,7 +505,7 @@ int IntelQaInit(void* threadId)
     }
 
     /* assign device id */
-    devId = (g_instCounter % g_numInstances);;
+    devId = (g_instCounter % g_numInstances);
     g_instCounter++;
 
     pthread_mutex_unlock(&g_Hwlock);
@@ -1685,7 +1685,6 @@ static void IntelQaRsaPublicFree(WC_ASYNC_DEV* dev)
             XFREE(opData->inputData.pData, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
             opData->inputData.pData = NULL;
         }
-        XMEMSET(opData->pPublicKey, 0, sizeof(CpaCyRsaPublicKey));
         XMEMSET(opData, 0, sizeof(CpaCyRsaEncryptOpData));
     }
     if (outBuf) {


### PR DESCRIPTION
* Fix for possible issue with QAT NUMA allocations failing and causing downstream issues.
* Fix to only call NUMA free if actually NUMA type.
* Fix to not use NUMA types for in/out if QAT cipher and hashing are disabled.
* Fix to resolve issue with repeated calls to IntelQaRsaPublicFree. The `pPublicKey` variable is a pointer and is cleared with `XMEMSET(opData`.
* Updates to README.md for Intel QAT.