### PR TITLE
Cleanup for non-NUMA alloc case

### DIFF
--- a/wolfcrypt/src/port/intel/quickassist_mem.c
+++ b/wolfcrypt/src/port/intel/quickassist_mem.c
@@ -408,7 +408,7 @@ static void* _qaeMemAlloc(size_t size, void* heap, int type
             alignment, &page_offset);
     #endif
     }
-    else if (ptr == NULL) {
+    else {
         isNuma = 0;
         ptr = malloc(size + sizeof(qaeMemHeader));
     }


### PR DESCRIPTION
ZD 5135. Customer request to cleanup. Don't fallback to malloc() in NUMA allocation failures. Instead report them upstream to caller.