### PR TITLE
Fix for not aligned NUMA

### DIFF
--- a/wolfcrypt/src/port/intel/README.md
+++ b/wolfcrypt/src/port/intel/README.md
@@ -16,9 +16,12 @@ The asynchronous crypto files are located at `wolfcrypt/src/async.c` and `wolfss
 QuickAssist drivers can be downloaded from Intel here:
 https://01.org/intel-quick-assist-technology/downloads
 
+The latest driver for QAT can be found here:
+https://www.intel.com/content/www/us/en/download/19734
+
 ### QAT 1.7
 
-This page will always have the latest QAT 1.7 Linux release:
+The latest QAT 1.7 Linux release:
 https://downloadcenter.intel.com/download/30178
 
 Note: If you have the older driver installed you may need to remove it or unload the module and reboot.

--- a/wolfcrypt/src/port/intel/quickassist_mem.c
+++ b/wolfcrypt/src/port/intel/quickassist_mem.c
@@ -563,6 +563,10 @@ void* IntelQaRealloc(void *ptr, size_t size, void* heap, int type
             if (newIsNuma == 0 && ptrIsNuma == 0) {
                 allocNew = 1;
             }
+            /* confirm input is aligned, otherwise allocate new */
+            else if (((size_t)ptr % WOLF_HEADER_ALIGN) != 0) {
+                allocNew = 1;
+            }
             /* if matching NUMA type and size fits, use existing */
             else if (newIsNuma == ptrIsNuma && header->size >= size) {
 


### PR DESCRIPTION
Found issue where AES GCM in buffer was NUMA type, but not aligned, which caused an encryption error.