### PR TITLE
20231107-pthread_attr_destroy-unused-return

### DIFF
--- a/wolfcrypt/src/async.c
+++ b/wolfcrypt/src/async.c
@@ -952,7 +952,9 @@ int wc_AsyncThreadCreate_ex(pthread_t *thread,
 exit_fail:
 
     fprintf(stderr, "AsyncThreadCreate error: %d\n", status);
-    (void)pthread_attr_destroy(&attr);
+    status = pthread_attr_destroy(&attr);
+    if (status != 0)
+        fprintf(stderr, "AsyncThreadCreate cleanup error: %d\n", status);
     return ASYNC_OP_E;
 }
 


### PR DESCRIPTION
`wolfcrypt/src/async.c`: check and report `retval` from `wc_AsyncThreadCreate_ex` in `exit_fail` section.

tested with `ASYNC_HEAD=local:20231107-pthread_attr_destroy-unused-return wolfssl-multi-test.sh ... clang-tidy-all-async-quic`.

fixes this:
```
[clang-tidy-all-async-quic] [183 of 207] [c852347dfb]
    configure...   real 0m19.932s  user 0m10.516s  sys 0m10.816s
    build.../home/wolfbot/tmp/wolfssl_test_workdir.2815/wolfssl/wolfcrypt/src/async.c:955:11: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors [bugprone-unused-return-value]
955 |     (void)pthread_attr_destroy(&attr);
|           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
