### PR TITLE
20250411-libwolfssl_sources_h

### DIFF
--- a/wolfcrypt/src/async.c
+++ b/wolfcrypt/src/async.c
@@ -19,17 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_ASYNC_CRYPT
 
 #include <wolfssl/internal.h>
 #include <wolfssl/error-ssl.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #include <wolfssl/wolfcrypt/async.h>
 


### PR DESCRIPTION
`wolfcrypt/src/async.c`: include `libwolfssl_sources.h`.

tested with `./configure --enable-fips=disabled --quiet --disable-jobserver '--enable-all' '--enable-testcert' '--enable-acert' '--enable-dtls13' '--enable-dtls-mtu' '--enable-dtls-frag-ch' '--enable-dtlscid' '--enable-quic' '--with-sys-crypto-policy' '--enable-asynccrypt' 'CFLAGS=-DTEST_ALWAYS_RUN_TO_END' 'CPPFLAGS=-DWOLFSSL_ECDSA_SET_K -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE'`
